### PR TITLE
Updating express.js dependency version. Locking to latest v. 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	],
 	"dependencies": {},
 	"devDependencies": {
-		"express": ""
+		"express": "^3.0.0"
 	},
 	"scripts": {
 		"start": "node bin/server"


### PR DESCRIPTION
Current example breaks with express v 4.x.x

Locking to v 3.x.x fixes the issue.